### PR TITLE
Update GitHub Actions to use latest upload-artifact version for coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.html


### PR DESCRIPTION
Upgrade the GitHub Actions workflow to utilize `actions/upload-artifact@v4` for uploading coverage reports.