### PR TITLE
Consolidate API client logic to eliminate code duplication

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -52,22 +51,6 @@ func clearScreen() {
 	}
 }
 
-// findNomiByName retrieves the UUID of a Nomi by its name using case-insensitive comparison.
-func findNomiByName(name string) (string, error) {
-	nomis, err := client.GetNomis()
-	if err != nil {
-		return "", err
-	}
-
-	// Search for the Nomi by name (case-insensitive)
-	for _, nomi := range nomis {
-		if strings.EqualFold(nomi.Name, name) {
-			return nomi.UUID, nil
-		}
-	}
-
-	return "", fmt.Errorf("no Nomi found with the name: %s", name)
-}
 
 // spinner displays a spinning wheel animation while waiting for a response.
 func spinner(stopChan chan bool) {

--- a/chat.go
+++ b/chat.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -54,41 +52,16 @@ func clearScreen() {
 	}
 }
 
-// findNomiByName retrieves the UUID of a Nomi by its name.
+// findNomiByName retrieves the UUID of a Nomi by its name using case-insensitive comparison.
 func findNomiByName(name string) (string, error) {
-	client := &http.Client{}
-	url := fmt.Sprintf("%s/nomis", baseURL) // Use dynamic baseURL
-
-	// Fetch the list of Nomis
-	req, err := http.NewRequest("GET", url, nil)
+	nomis, err := client.GetNomis()
 	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("error making request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error fetching Nomis: %s", resp.Status)
+		return "", err
 	}
 
-	var result struct {
-		Nomis []struct {
-			UUID string `json:"uuid"`
-			Name string `json:"name"`
-		} `json:"nomis"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("error decoding response: %v", err)
-	}
-
-	// Search for the Nomi by name
-	for _, nomi := range result.Nomis {
-		if strings.EqualFold(nomi.Name, name) { // Case-insensitive comparison
+	// Search for the Nomi by name (case-insensitive)
+	for _, nomi := range nomis {
+		if strings.EqualFold(nomi.Name, name) {
 			return nomi.UUID, nil
 		}
 	}

--- a/chat_test.go
+++ b/chat_test.go
@@ -46,6 +46,9 @@ func TestFindNomiByName(t *testing.T) {
 	apiKey = "test-api-key"
 	baseURL = server.URL
 
+	// Initialize the client for testing
+	client = NewNomiClient(apiKey, baseURL)
+
 	// Test finding existing Nomi
 	uuid, err := findNomiByName("John")
 	if err != nil {

--- a/chat_test.go
+++ b/chat_test.go
@@ -50,7 +50,7 @@ func TestFindNomiByName(t *testing.T) {
 	client = NewNomiClient(apiKey, baseURL)
 
 	// Test finding existing Nomi
-	uuid, err := findNomiByName("John")
+	uuid, err := client.FindNomiByName("John")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -58,8 +58,17 @@ func TestFindNomiByName(t *testing.T) {
 		t.Errorf("Expected UUID test-uuid-1, got %s", uuid)
 	}
 
+	// Test case-insensitive matching
+	uuid, err = client.FindNomiByName("JOHN")
+	if err != nil {
+		t.Errorf("Expected no error for case-insensitive match, got %v", err)
+	}
+	if uuid != "test-uuid-1" {
+		t.Errorf("Expected UUID test-uuid-1 for case-insensitive match, got %s", uuid)
+	}
+
 	// Test finding non-existent Nomi
-	_, err = findNomiByName("NonExistent")
+	_, err = client.FindNomiByName("NonExistent")
 	if err == nil {
 		t.Error("Expected error for non-existent Nomi, got none")
 	}

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -70,10 +71,17 @@ func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, resu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		var errorMessage string
+		if bodyBytes, err := io.ReadAll(resp.Body); err == nil && len(bodyBytes) > 0 {
+			errorMessage = fmt.Sprintf("Request to %s failed: %s", endpoint, string(bodyBytes))
+		} else {
+			errorMessage = fmt.Sprintf("Request to %s failed", endpoint)
+		}
+		
 		return &APIError{
 			Status:     resp.Status,
 			StatusCode: resp.StatusCode,
-			Message:    fmt.Sprintf("Request to %s failed", endpoint),
+			Message:    errorMessage,
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type NomiClient struct {
+	httpClient *http.Client
+	apiKey     string
+	baseURL    string
+}
+
+type APIError struct {
+	Status     string
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (%d %s): %s", e.StatusCode, e.Status, e.Message)
+}
+
+func NewNomiClient(apiKey, baseURL string) *NomiClient {
+	return &NomiClient{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		apiKey:  apiKey,
+		baseURL: baseURL,
+	}
+}
+
+func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, result interface{}) error {
+	var reqBody *bytes.Buffer
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("error marshaling request body: %w", err)
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	url := fmt.Sprintf("%s%s", c.baseURL, endpoint)
+	var req *http.Request
+	var err error
+
+	if reqBody != nil {
+		req, err = http.NewRequest(method, url, reqBody)
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return &APIError{
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("Request to %s failed", endpoint),
+		}
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("error decoding response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *NomiClient) GetNomis() ([]Nomi, error) {
+	var response NomiResponse
+	err := c.makeRequest("GET", "/nomis", nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.Nomis, nil
+}
+
+func (c *NomiClient) GetNomi(id string) (*Nomi, error) {
+	var nomi Nomi
+	endpoint := fmt.Sprintf("/nomis/%s", id)
+	err := c.makeRequest("GET", endpoint, nil, &nomi)
+	if err != nil {
+		return nil, err
+	}
+	return &nomi, nil
+}
+
+func (c *NomiClient) GetRooms() ([]Room, error) {
+	var response RoomResponse
+	err := c.makeRequest("GET", "/rooms", nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.Rooms, nil
+}
+
+func (c *NomiClient) SendMessage(nomiID, message string) (*ChatResponse, error) {
+	var response ChatResponse
+	endpoint := fmt.Sprintf("/nomis/%s/chat", nomiID)
+	requestBody := ChatRequest{MessageText: message}
+	err := c.makeRequest("POST", endpoint, requestBody, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *NomiClient) FindNomiByName(name string) (string, error) {
+	nomis, err := c.GetNomis()
+	if err != nil {
+		return "", err
+	}
+
+	for _, nomi := range nomis {
+		if nomi.Name == name {
+			return nomi.UUID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no Nomi found with the name: %s", name)
+}

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -140,7 +141,7 @@ func (c *NomiClient) FindNomiByName(name string) (string, error) {
 	}
 
 	for _, nomi := range nomis {
-		if nomi.Name == name {
+		if strings.EqualFold(nomi.Name, name) {
 			return nomi.UUID, nil
 		}
 	}

--- a/get_nomi.go
+++ b/get_nomi.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/spf13/cobra"
 )
@@ -14,37 +12,9 @@ var getNomiCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the Nomi ID)
 	Run: func(cmd *cobra.Command, args []string) {
 		id := args[0]
-		client := &http.Client{}
-		url := fmt.Sprintf("%s/nomis/%s", baseURL, id) // Use dynamic baseURL
-
-		// Create the request
-		req, err := http.NewRequest("GET", url, nil)
+		nomi, err := client.GetNomi(id)
 		if err != nil {
-			fmt.Println("Error creating request:", err)
-			return
-		}
-
-		// Set the Authorization header
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-
-		// Perform the request
-		resp, err := client.Do(req)
-		if err != nil {
-			fmt.Println("Error making request:", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		// Check the response status
-		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Error: %s\n", resp.Status)
-			return
-		}
-
-		// Parse the response body
-		var nomi Nomi
-		if err := json.NewDecoder(resp.Body).Decode(&nomi); err != nil {
-			fmt.Println("Error decoding response:", err)
+			fmt.Println("Error fetching Nomi:", err)
 			return
 		}
 

--- a/get_nomi_test.go
+++ b/get_nomi_test.go
@@ -42,8 +42,10 @@ func TestGetNomiCmdSuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override baseURL
+	// Override baseURL and initialize client
 	baseURL = server.URL
+	apiKey = "test-api-key"
+	client = NewNomiClient(apiKey, baseURL)
 
 	// Capture stdout
 	oldStdout := os.Stdout
@@ -89,8 +91,10 @@ func TestGetNomiCmdNotFound(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override baseURL
+	// Override baseURL and initialize client
 	baseURL = server.URL
+	apiKey = "test-api-key"
+	client = NewNomiClient(apiKey, baseURL)
 
 	// Capture stdout
 	oldStdout := os.Stdout
@@ -112,8 +116,8 @@ func TestGetNomiCmdNotFound(t *testing.T) {
 	outputStr := string(outBytes)
 
 	// Check that output indicates an error
-	if !strings.Contains(outputStr, "Error: 404 Not Found") {
-		t.Errorf("Expected output to contain \"Error: 404 Not Found\", got %q", outputStr)
+	if !strings.Contains(outputStr, "API error (404") {
+		t.Errorf("Expected output to contain API error 404, got %q", outputStr)
 	}
 }
 
@@ -124,8 +128,10 @@ func TestGetNomiCmdServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override baseURL
+	// Override baseURL and initialize client
 	baseURL = server.URL
+	apiKey = "test-api-key"
+	client = NewNomiClient(apiKey, baseURL)
 
 	// Capture stdout
 	oldStdout := os.Stdout
@@ -145,8 +151,8 @@ func TestGetNomiCmdServerError(t *testing.T) {
 	outBytes, _ := io.ReadAll(rOut)
 	outputStr := string(outBytes)
 
-	if !strings.Contains(outputStr, "Error: 500 Internal Server Error") {
-		t.Errorf("Expected output to contain \"Error: 500 Internal Server Error\", got %q", outputStr)
+	if !strings.Contains(outputStr, "API error (500") {
+		t.Errorf("Expected output to contain API error 500, got %q", outputStr)
 	}
 }
 

--- a/list_nomis.go
+++ b/list_nomis.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/spf13/cobra"
 )
@@ -14,34 +12,14 @@ var listNomisCmd = &cobra.Command{
 	Use:   "list-nomis",
 	Short: "List all Nomis",
 	Run: func(cmd *cobra.Command, args []string) {
-		client := &http.Client{}
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/nomis", baseURL), nil)
+		nomis, err := client.GetNomis()
 		if err != nil {
-			fmt.Println("Error creating request:", err)
-			return
-		}
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-
-		resp, err := client.Do(req)
-		if err != nil {
-			fmt.Println("Error making request:", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Error: %s\n", resp.Status)
-			return
-		}
-
-		var result NomiResponse
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Println("Error decoding response:", err)
+			fmt.Println("Error fetching Nomis:", err)
 			return
 		}
 
 		// Display the Nomis
-		for _, nomi := range result.Nomis {
+		for _, nomi := range nomis {
 			if fullOutput {
 				// Full output
 				fmt.Printf("- ID: %s\n  Name: %s\n  Gender: %s\n  Created: %s\n  Relationship: %s\n\n",

--- a/list_rooms.go
+++ b/list_rooms.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/spf13/cobra"
 )
@@ -41,43 +39,15 @@ var listRoomsCmd = &cobra.Command{
 	Short: "List all rooms",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := &http.Client{}
-		url := baseURL + "/rooms"
-
-		// Create the request
-		req, err := http.NewRequest("GET", url, nil)
+		rooms, err := client.GetRooms()
 		if err != nil {
-			fmt.Println("Error creating request:", err)
-			return
-		}
-
-		// Set the Authorization header
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-
-		// Perform the request
-		resp, err := client.Do(req)
-		if err != nil {
-			fmt.Println("Error making request:", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		// Check the response status
-		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Error: %s\n", resp.Status)
-			return
-		}
-
-		// Parse the response body
-		var response RoomResponse
-		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			fmt.Println("Error decoding response:", err)
+			fmt.Println("Error fetching rooms:", err)
 			return
 		}
 
 		// Print the Rooms
-		fmt.Printf("Total Rooms: %d\n\n", len(response.Rooms))
-		for _, room := range response.Rooms {
+		fmt.Printf("Total Rooms: %d\n\n", len(rooms))
+		for _, room := range rooms {
 			displayRoom(room)
 			fmt.Println()
 		}

--- a/list_rooms_test.go
+++ b/list_rooms_test.go
@@ -147,8 +147,10 @@ func TestListRoomsCmd(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override baseURL for testing
+	// Override baseURL and initialize client for testing
 	baseURL = server.URL
+	apiKey = "test-api-key"
+	client = NewNomiClient(apiKey, baseURL)
 
 	// Capture output
 	old := os.Stdout
@@ -194,8 +196,10 @@ func TestListRoomsCmdError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override baseURL for testing
+	// Override baseURL and initialize client for testing
 	baseURL = server.URL
+	apiKey = "test-api-key"
+	client = NewNomiClient(apiKey, baseURL)
 
 	// Capture output
 	old := os.Stdout
@@ -217,7 +221,7 @@ func TestListRoomsCmdError(t *testing.T) {
 	outputStr := string(out)
 
 	// We expect an error message in the output
-	if !strings.Contains(outputStr, "Error: 500 Internal Server Error") {
-		t.Errorf("Expected output to contain server error message, got %q", outputStr)
+	if !strings.Contains(outputStr, "API error (500") {
+		t.Errorf("Expected output to contain API error 500, got %q", outputStr)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var apiKey string  // Store the API key globally
-var baseURL string // Store the base API URL globally
+var apiKey string      // Store the API key globally
+var baseURL string     // Store the base API URL globally
+var client *NomiClient // Global API client
 
 func main() {
 	var rootCmd = &cobra.Command{
@@ -30,6 +31,9 @@ func main() {
 			if baseURL == "" {
 				baseURL = "https://api.nomi.ai/v1" // Default value if environment variable is not set
 			}
+
+			// Initialize the API client
+			client = NewNomiClient(apiKey, baseURL)
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -38,7 +42,7 @@ func main() {
 			go spinner(stopChan)
 
 			// Get the list of Nomis
-			nomis, err := fetchNomis()
+			nomis, err := client.GetNomis()
 
 			// Stop the spinner
 			close(stopChan)

--- a/selectable_menu.go
+++ b/selectable_menu.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/charmbracelet/bubbletea"
 )
@@ -101,31 +99,4 @@ func selectableMenu(nomis []Nomi) (Nomi, error) {
 	}
 
 	return Nomi{}, fmt.Errorf("unexpected model type")
-}
-
-// fetchNomis retrieves the list of Nomis from the API
-func fetchNomis() ([]Nomi, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/nomis", baseURL), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %v", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error making request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error: %s", resp.Status)
-	}
-
-	var result NomiResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
-	}
-
-	return result.Nomis, nil
 }

--- a/selectable_menu_test.go
+++ b/selectable_menu_test.go
@@ -12,13 +12,13 @@ func TestModelInit(t *testing.T) {
 		{UUID: "123", Name: "Alice", RelationshipType: "Friend"},
 		{UUID: "456", Name: "Bob", RelationshipType: "Mentor"},
 	}
-	
+
 	m := model{
 		nomis:    mockNomis,
 		cursor:   0,
 		selected: -1,
 	}
-	
+
 	cmd := m.Init()
 	if cmd != nil {
 		t.Errorf("Expected nil command from Init(), got %v", cmd)
@@ -30,7 +30,7 @@ func TestModelUpdate(t *testing.T) {
 		{UUID: "123", Name: "Alice", RelationshipType: "Friend"},
 		{UUID: "456", Name: "Bob", RelationshipType: "Mentor"},
 	}
-	
+
 	tests := []struct {
 		name           string
 		initialCursor  int
@@ -102,7 +102,7 @@ func TestModelUpdate(t *testing.T) {
 			expectedQuit:   true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := model{
@@ -110,21 +110,21 @@ func TestModelUpdate(t *testing.T) {
 				cursor:   tt.initialCursor,
 				selected: -1,
 			}
-			
+
 			updatedModel, cmd := m.Update(tt.keyMsg)
-			
+
 			// Type assertion
 			updated, ok := updatedModel.(model)
 			if !ok {
 				t.Fatalf("Expected model type, got %T", updatedModel)
 			}
-			
+
 			// Check cursor position
 			if updated.cursor != tt.expectedCursor {
-				t.Errorf("Expected cursor to be %d, got %d", 
+				t.Errorf("Expected cursor to be %d, got %d",
 					tt.expectedCursor, updated.cursor)
 			}
-			
+
 			// For Enter key, check that selection was made
 			if tt.keyMsg.Type == tea.KeyEnter {
 				if updated.selected != tt.initialCursor {
@@ -132,7 +132,7 @@ func TestModelUpdate(t *testing.T) {
 						tt.initialCursor, updated.selected)
 				}
 			}
-			
+
 			// For quit commands, we can only verify that a command was returned
 			// Full tea.Quit testing would require a more complex mock setup
 			if tt.expectedQuit && cmd == nil {
@@ -147,26 +147,26 @@ func TestModelView(t *testing.T) {
 		{UUID: "123", Name: "Alice", RelationshipType: "Friend"},
 		{UUID: "456", Name: "Bob", RelationshipType: "Mentor"},
 	}
-	
+
 	m := model{
 		nomis:    mockNomis,
 		cursor:   0,
 		selected: -1,
 	}
-	
+
 	output := m.View()
-	
+
 	// Test that view contains all Nomis
 	for _, nomi := range mockNomis {
 		if !contains(output, nomi.Name) {
 			t.Errorf("View output doesn't contain Nomi name: %s", nomi.Name)
 		}
-		
+
 		if !contains(output, nomi.RelationshipType) {
 			t.Errorf("View output doesn't contain relationship type: %s", nomi.RelationshipType)
 		}
 	}
-	
+
 	// Test that view contains the names
 	if !contains(output, "Alice") {
 		t.Errorf("View output doesn't contain first Nomi name")

--- a/start_chat.go
+++ b/start_chat.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/chzyer/readline"
@@ -22,9 +19,6 @@ func startChat(name string) {
 		fmt.Println(err)
 		return
 	}
-
-	client := &http.Client{}
-	url := fmt.Sprintf("%s/nomis/%s/chat", baseURL, nomiID)
 
 	// Clear the terminal at the start of the chat
 	clearScreen()
@@ -70,29 +64,12 @@ func startChat(name string) {
 			break
 		}
 
-		// Prepare the request payload
-		chatRequest := ChatRequest{MessageText: input}
-		requestBody, err := json.Marshal(chatRequest)
-		if err != nil {
-			fmt.Println("Error encoding request body:", err)
-			continue
-		}
-
-		// Create the HTTP request
-		req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
-		if err != nil {
-			fmt.Println("Error creating request:", err)
-			continue
-		}
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-		req.Header.Set("Content-Type", "application/json")
-
 		// Start the spinner
 		stopChan := make(chan bool)
 		go spinner(stopChan)
 
-		// Send the request
-		resp, err := client.Do(req)
+		// Send the message using the API client
+		chatResponse, err := client.SendMessage(nomiID, input)
 
 		// Stop the spinner
 		close(stopChan)
@@ -100,20 +77,6 @@ func startChat(name string) {
 
 		if err != nil {
 			fmt.Println("Error sending message:", err)
-			continue
-		}
-		defer resp.Body.Close()
-
-		// Check for successful response
-		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Error: %s\n", resp.Status)
-			continue
-		}
-
-		// Decode the response
-		var chatResponse ChatResponse
-		if err := json.NewDecoder(resp.Body).Decode(&chatResponse); err != nil {
-			fmt.Println("Error decoding response:", err)
 			continue
 		}
 

--- a/start_chat.go
+++ b/start_chat.go
@@ -14,7 +14,7 @@ func startChat(name string) {
 	defer clearScreen()
 
 	// Find the UUID for the given name
-	nomiID, err := findNomiByName(name)
+	nomiID, err := client.FindNomiByName(name)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/start_chat_test.go
+++ b/start_chat_test.go
@@ -51,8 +51,11 @@ func TestFetchNomis(t *testing.T) {
 	apiKey = "test-api-key"
 	baseURL = mockServer.URL
 
+	// Initialize the client for testing
+	client = NewNomiClient(apiKey, baseURL)
+
 	// Test fetching Nomis
-	nomis, err := fetchNomis()
+	nomis, err := client.GetNomis()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return


### PR DESCRIPTION
- Create centralized NomiClient in client.go with reusable HTTP request patterns 

- Add structured error handling with APIError type and 30s timeout configuration                                                                                    

- Refactor all commands (list-nomis, get-nomi, list-rooms, chat) to use shared client 
                                                                      
- Remove ~100 lines of duplicate HTTP client creation and auth header logic 

- Update tests to use new client architecture and fix error message expectations

- Maintain all existing functionality while improving code maintainability