### PR TITLE
Fix chat timeout errors with per-request timeouts and retries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,10 @@ Nomi CLI is a command-line interface tool for interacting with the Nomi.ai API, 
 - **Main Application Structure**: Uses Cobra for CLI command management
 - **API Client**: Centralized `NomiClient` in `client.go` handles all HTTP communication
   - Structured error handling with `APIError` type
-  - 30-second timeout configuration
+  - Per-request timeouts via `context`: 30s for standard calls, 120s for chat
+    (the `/chat` endpoint triggers LLM generation and is slow). Overridable
+    with `NOMI_API_TIMEOUT` / `NOMI_CHAT_TIMEOUT` (seconds or Go durations).
+  - Chat requests retry transient failures (timeouts, 5xx) with exponential backoff
   - Reusable request patterns with authentication headers
   - Methods: `GetNomis()`, `GetNomi()`, `GetRooms()`, `SendMessage()`, `FindNomiByName()`
 - **Authentication**: Uses API key in environment variable or passed as a flag
@@ -86,6 +89,7 @@ The CLI requires configuration for the Nomi.ai API:
 
 - API Key: Set via `NOMI_API_KEY` environment variable or `-k/--api-key` flag
 - API URL: Set via `NOMI_API_URL` environment variable (defaults to "https://api.nomi.ai/v1")
+- Timeouts (optional): `NOMI_API_TIMEOUT` (default 30s) and `NOMI_CHAT_TIMEOUT` (default 120s); accepts plain seconds (`180`) or Go durations (`3m`)
 
 Example:
 ```bash
@@ -99,7 +103,7 @@ The application uses a centralized API client pattern implemented in `client.go`
 
 ### NomiClient Structure
 - **Initialization**: Created once in `main.go` during `PersistentPreRunE` and stored as global `client` variable
-- **HTTP Client**: Reuses single HTTP client instance with 30-second timeout
+- **HTTP Client**: Reuses a single HTTP client instance; each request is bounded by its own `context` timeout (30s default, 120s for chat)
 - **Error Handling**: Returns structured `APIError` with status codes and descriptive messages
 - **Authentication**: Automatically adds Bearer token headers to all requests
 

--- a/client.go
+++ b/client.go
@@ -2,18 +2,53 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
 
+// Default per-request timeouts. Chat is generous because the /chat endpoint
+// triggers LLM generation on Nomi's side, which routinely exceeds 30s.
+const (
+	defaultRequestTimeout = 30 * time.Second
+	defaultChatTimeout    = 120 * time.Second
+)
+
+// Retry policy for chat requests, which can fail transiently (timeouts,
+// 5xx responses). maxChatRetries is the number of retries after the first
+// attempt; backoff doubles each retry starting from chatRetryBackoff.
+const maxChatRetries = 2
+
+// chatRetryBackoff is the delay before the first retry; it doubles for each
+// subsequent retry. Declared as a var so tests can shrink it.
+var chatRetryBackoff = 2 * time.Second
+
 type NomiClient struct {
-	httpClient *http.Client
-	apiKey     string
-	baseURL    string
+	httpClient     *http.Client
+	apiKey         string
+	baseURL        string
+	requestTimeout time.Duration
+	chatTimeout    time.Duration
+}
+
+// envDuration reads a timeout (in seconds) from an environment variable,
+// falling back to def if unset or invalid.
+func envDuration(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		if secs, err := time.ParseDuration(v + "s"); err == nil {
+			return secs
+		}
+	}
+	return def
 }
 
 type APIError struct {
@@ -28,15 +63,17 @@ func (e *APIError) Error() string {
 
 func NewNomiClient(apiKey, baseURL string) *NomiClient {
 	return &NomiClient{
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		apiKey:  apiKey,
-		baseURL: baseURL,
+		// No Client.Timeout: each request is bounded by its own context
+		// so chat can wait longer than other calls.
+		httpClient:     &http.Client{},
+		apiKey:         apiKey,
+		baseURL:        baseURL,
+		requestTimeout: envDuration("NOMI_API_TIMEOUT", defaultRequestTimeout),
+		chatTimeout:    envDuration("NOMI_CHAT_TIMEOUT", defaultChatTimeout),
 	}
 }
 
-func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, result interface{}) error {
+func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, result interface{}, timeout time.Duration) error {
 	var reqBody *bytes.Buffer
 	if body != nil {
 		jsonData, err := json.Marshal(body)
@@ -50,10 +87,13 @@ func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, resu
 	var req *http.Request
 	var err error
 
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	if reqBody != nil {
-		req, err = http.NewRequest(method, url, reqBody)
+		req, err = http.NewRequestWithContext(ctx, method, url, reqBody)
 	} else {
-		req, err = http.NewRequest(method, url, nil)
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
 	}
 
 	if err != nil {
@@ -67,6 +107,9 @@ func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, resu
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("request to %s timed out after %s (try raising NOMI_CHAT_TIMEOUT): %w", endpoint, timeout, ctx.Err())
+		}
 		return fmt.Errorf("error making request: %w", err)
 	}
 	defer resp.Body.Close()
@@ -97,7 +140,7 @@ func (c *NomiClient) makeRequest(method, endpoint string, body interface{}, resu
 
 func (c *NomiClient) GetNomis() ([]Nomi, error) {
 	var response NomiResponse
-	err := c.makeRequest("GET", "/nomis", nil, &response)
+	err := c.makeRequest("GET", "/nomis", nil, &response, c.requestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +150,7 @@ func (c *NomiClient) GetNomis() ([]Nomi, error) {
 func (c *NomiClient) GetNomi(id string) (*Nomi, error) {
 	var nomi Nomi
 	endpoint := fmt.Sprintf("/nomis/%s", id)
-	err := c.makeRequest("GET", endpoint, nil, &nomi)
+	err := c.makeRequest("GET", endpoint, nil, &nomi, c.requestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -116,22 +159,49 @@ func (c *NomiClient) GetNomi(id string) (*Nomi, error) {
 
 func (c *NomiClient) GetRooms() ([]Room, error) {
 	var response RoomResponse
-	err := c.makeRequest("GET", "/rooms", nil, &response)
+	err := c.makeRequest("GET", "/rooms", nil, &response, c.requestTimeout)
 	if err != nil {
 		return nil, err
 	}
 	return response.Rooms, nil
 }
 
+// isRetryable reports whether err is a transient failure worth retrying:
+// a request timeout or a 5xx server response.
+func isRetryable(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500
+	}
+	return false
+}
+
 func (c *NomiClient) SendMessage(nomiID, message string) (*ChatResponse, error) {
-	var response ChatResponse
 	endpoint := fmt.Sprintf("/nomis/%s/chat", nomiID)
 	requestBody := ChatRequest{MessageText: message}
-	err := c.makeRequest("POST", endpoint, requestBody, &response)
-	if err != nil {
-		return nil, err
+
+	var lastErr error
+	for attempt := 0; attempt <= maxChatRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(chatRetryBackoff << (attempt - 1))
+		}
+
+		var response ChatResponse
+		err := c.makeRequest("POST", endpoint, requestBody, &response, c.chatTimeout)
+		if err == nil {
+			return &response, nil
+		}
+
+		lastErr = err
+		if !isRetryable(err) {
+			return nil, err
+		}
 	}
-	return &response, nil
+
+	return nil, fmt.Errorf("chat request failed after %d attempts: %w", maxChatRetries+1, lastErr)
 }
 
 func (c *NomiClient) FindNomiByName(name string) (string, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// chatOKResponse writes a valid ChatResponse echoing the incoming message.
+func chatOKResponse(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(ChatResponse{
+		SentMessage:  Message{UUID: "msg-1", Text: "Hello", Sent: "2024-01-01T12:00:00Z"},
+		ReplyMessage: Message{UUID: "msg-2", Text: "Test response", Sent: "2024-01-01T12:00:01Z"},
+	})
+}
+
+// withFastRetries shrinks the retry backoff so tests don't sleep for real
+// seconds, restoring the original value when the test ends.
+func withFastRetries(t *testing.T) {
+	t.Helper()
+	orig := chatRetryBackoff
+	chatRetryBackoff = time.Millisecond
+	t.Cleanup(func() { chatRetryBackoff = orig })
+}
+
+func TestSendMessageRetriesOn503(t *testing.T) {
+	withFastRetries(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		chatOKResponse(w)
+	}))
+	defer server.Close()
+
+	c := NewNomiClient("test-api-key", server.URL)
+	resp, err := c.SendMessage("test-uuid", "Hello")
+	if err != nil {
+		t.Fatalf("Expected success after retry, got error: %v", err)
+	}
+	if resp.ReplyMessage.Text != "Test response" {
+		t.Errorf("Expected reply %q, got %q", "Test response", resp.ReplyMessage.Text)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("Expected 2 requests (1 failure + 1 retry), got %d", got)
+	}
+}
+
+func TestSendMessageRetriesOnTimeout(t *testing.T) {
+	withFastRetries(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// Stall past the chat timeout so the first attempt is aborted.
+			time.Sleep(150 * time.Millisecond)
+			return
+		}
+		chatOKResponse(w)
+	}))
+	defer server.Close()
+
+	c := NewNomiClient("test-api-key", server.URL)
+	c.chatTimeout = 50 * time.Millisecond
+
+	resp, err := c.SendMessage("test-uuid", "Hello")
+	if err != nil {
+		t.Fatalf("Expected success after timeout retry, got error: %v", err)
+	}
+	if resp.ReplyMessage.Text != "Test response" {
+		t.Errorf("Expected reply %q, got %q", "Test response", resp.ReplyMessage.Text)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("Expected 2 requests (1 timeout + 1 retry), got %d", got)
+	}
+}
+
+func TestSendMessageNoRetryOn400(t *testing.T) {
+	withFastRetries(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	c := NewNomiClient("test-api-key", server.URL)
+	if _, err := c.SendMessage("test-uuid", "Hello"); err == nil {
+		t.Fatal("Expected error for 400 response, got none")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("Expected 1 request (4xx is not retried), got %d", got)
+	}
+}
+
+func TestSendMessageFailsAfterMaxRetries(t *testing.T) {
+	withFastRetries(t)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	c := NewNomiClient("test-api-key", server.URL)
+	_, err := c.SendMessage("test-uuid", "Hello")
+	if err == nil {
+		t.Fatal("Expected error after exhausting retries, got none")
+	}
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Errorf("Expected error to mention attempt count, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != maxChatRetries+1 {
+		t.Errorf("Expected %d requests, got %d", maxChatRetries+1, got)
+	}
+}


### PR DESCRIPTION
## Problem

Sending a chat message frequently failed with:

```
Error sending message: error making request: Post ".../chat": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The `NomiClient` used a single `http.Client{Timeout: 30s}` covering **every** request. The `/chat` endpoint triggers LLM generation on Nomi's side, which routinely takes longer than 30s — so the client gave up before Nomi finished responding.

## Changes

- **Per-request timeouts via `context`** instead of one global client timeout — 30s for standard calls, 120s for chat.
- **Overridable via env vars** — `NOMI_API_TIMEOUT` / `NOMI_CHAT_TIMEOUT` (plain seconds or Go durations).
- **Retry-with-backoff on `SendMessage`** — retries transient failures (request timeouts, 5xx) up to 2 times with exponential backoff (2s → 4s). 4xx responses fail immediately.
- **Clearer timeout error** — surfaces the endpoint, the timeout hit, and a hint to raise `NOMI_CHAT_TIMEOUT`.
- **Tests** — new `client_test.go` covering retry-on-503, retry-on-timeout, no-retry-on-400, and failure-after-max-retries.
- **CLAUDE.md** updated to reflect the new timeout model.

## Testing

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)