### PR TITLE
Restrict GITHUB_TOKEN permissions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
Resolves code-scanning alert [#1](https://github.com/sjourdan/nomi-cli/security/code-scanning/1) (`actions/missing-workflow-permissions`).

## What

Adds a root-level `permissions: contents: read` block to `.github/workflows/test.yml`.

## Why

Without an explicit `permissions` block, the workflow inherits the repository's default `GITHUB_TOKEN` scope, which may be read-write. The Tests workflow only checks out code, runs Go tests, and uploads a coverage artifact — none of which need write access. `contents: read` is the least privilege required and matches CodeQL's suggested minimal starting point.

`build.yml` already declares its own `permissions` block, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)